### PR TITLE
Issue Fix for SearchBar Auto Focus in TUIAppTopBar

### DIFF
--- a/Sources/TarkaUI/Components/App Bar/TUIAppTopBar.swift
+++ b/Sources/TarkaUI/Components/App Bar/TUIAppTopBar.swift
@@ -147,7 +147,7 @@ public struct TUIAppTopBar: View {
       .padding(.horizontal, Spacing.baseHorizontal)
       .padding(.vertical, Spacing.baseVertical)
       .onAppear {
-        searchBarVM.isEditing = true
+        searchBarVM.isEditing = searchBarVM.isFocused
       }
   }
 }

--- a/Sources/TarkaUI/Components/Search Bar/SearchTextField.swift
+++ b/Sources/TarkaUI/Components/Search Bar/SearchTextField.swift
@@ -23,6 +23,7 @@ struct SearchTextField: View {
       .onChange(of: searchBarVM.isEditing, perform: { value in
         if value != isFocused {
           isFocused = value
+          searchBarVM.isFocused = value
         }
       })
       .accessibilityIdentifier(Accessibility.root)

--- a/Sources/TarkaUI/Components/Search Bar/TUISearchBarViewModel.swift
+++ b/Sources/TarkaUI/Components/Search Bar/TUISearchBarViewModel.swift
@@ -26,6 +26,7 @@ public class TUISearchBarViewModel: ObservableObject {
   @Published public var searchItem: TUISearchBarItem
   @Published public var isShown: Bool = false
   @Published public var isEditing = false
+  @Published public var isFocused = true
   
   @Published public var searchText = ""
   


### PR DESCRIPTION
While using appear `searchBar.isEditing = true`, searchBar is auto focused when we go detail screen and back go list screen, so Created `isFocused`